### PR TITLE
bugfix: cards__description display fixed

### DIFF
--- a/blocks/cards/__description/cards__description.css
+++ b/blocks/cards/__description/cards__description.css
@@ -1,3 +1,13 @@
 .cards__description {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  gap: 20px;
   margin: 0;
+}
+
+@media screen and (max-width: 1279px) {
+  .cards__description {
+    gap: 10px;
+  }
 }

--- a/blocks/cards/__text/cards__text.css
+++ b/blocks/cards/__text/cards__text.css
@@ -3,13 +3,11 @@
   line-height: 120%;
   font-weight: 400;
   margin: 0;
-  margin-top: 20px;
 }
 
 @media screen and (max-width: 1279px) {
   .cards__text {
     font-size: 16px;
-    margin-top: 10px;
   }
 }
 


### PR DESCRIPTION
__description now is flex-container
__text don't have margin-top

Co-Authored-By: Vladyslav Fomin <57030653+digital-nomadd@users.noreply.github.com>